### PR TITLE
Day11

### DIFF
--- a/exercise/java/day11/.gitignore
+++ b/exercise/java/day11/.gitignore
@@ -1,1 +1,2 @@
 .cifuzz-corpus/**
+/.jqwik-database

--- a/exercise/java/day11/.gitignore
+++ b/exercise/java/day11/.gitignore
@@ -1,0 +1,1 @@
+.cifuzz-corpus/**

--- a/exercise/java/day11/log.md
+++ b/exercise/java/day11/log.md
@@ -20,3 +20,7 @@
 - toying with jazzer
   - found div by zero problems in several variations (+/- small constants, +/- other var) rather quickly
     - to introduce div by zero, i changed `(double) toysCount / totalToys` to variations of `(double) (toysCount / totalToys)`
+- more toying with pitest, trying to get it to detect the bad detection of double constant changes
+  - using STRONGER and ALL mutations did not help
+  - found no docs of more double mutators in arcmutate (paid extension), but didn't bother to try
+  - gave up and created additional testcases without a tool telling me to 

--- a/exercise/java/day11/log.md
+++ b/exercise/java/day11/log.md
@@ -1,0 +1,2 @@
+- totalToys == 0
+- age < 0

--- a/exercise/java/day11/log.md
+++ b/exercise/java/day11/log.md
@@ -23,4 +23,7 @@
 - more toying with pitest, trying to get it to detect the bad detection of double constant changes
   - using STRONGER and ALL mutations did not help
   - found no docs of more double mutators in arcmutate (paid extension), but didn't bother to try
-  - gave up and created additional testcases without a tool telling me to 
+  - gave up and created additional testcases without a tool telling me to
+- tried again with jqwik
+  - dead simple to setup
+  - nice detection of several non-trivial div by zero bugs 

--- a/exercise/java/day11/log.md
+++ b/exercise/java/day11/log.md
@@ -1,2 +1,8 @@
 - totalToys == 0
 - age < 0
+- setup of pitest not straightforward
+  - failed due to junit-jupiter missing in dependencies
+  - maven tests ran despite missing dep
+  - failure output of pitest hard interpret
+- can call maven commands in intellij via button on top (despite no local installation of mvn)
+- 

--- a/exercise/java/day11/log.md
+++ b/exercise/java/day11/log.md
@@ -5,4 +5,16 @@
   - maven tests ran despite missing dep
   - failure output of pitest hard interpret
 - can call maven commands in intellij via button on top (despite no local installation of mvn)
-- 
+- pitest results:
+  - private constructor is not covered, but we'll leave that as is, as it prevents constructing the static class
+  - added some tests at the age boundaries for categorize gift
+- will try [datafaker](https://www.datafaker.net/) to add random data tests
+  - datafaker is pretty simple to set up and use with parameterized tests
+  - readability for more than one parameter via @MethodSource is not great
+  - suspected "division by 0" is not a problem for doubles
+  - finding edge cases like div by zero would take huge amounts of time with randomized values
+    - datafaker seems to be aimed more at anonymizing data, and maybe property based testing
+    - are fuzzing libs better at detecting corner cases?  
+- review of pitest findings:
+  - ! can alter doubles in ensureToyBalance without a test failing
+  - 

--- a/exercise/java/day11/log.md
+++ b/exercise/java/day11/log.md
@@ -1,3 +1,39 @@
+## TL;DR My personal highlights
+
+- Pitest (Mutation testing for java)
+  - can help spot logical loopholes in tests
+  - does not spot all logical  loopholes (i.e. "off by a little" in floating point numbers)
+  - can be hard to set up
+- about spotting edge cases that lead to bugs
+  - tests with purely random generated data (or datafaker) have a very bad chance of catching those bugs  
+  - dedicated fuzz testing (i.e. with jazzer) does way better in this regard, but is hard to set up
+  - dedicated property based testing (jqwick) also works well and was a breeze to set up
+- datafaker is nice for generating reality-like data nonetheless
+
+## Thougths afterwards
+
+- ChatGPT is not particularly helpful for setting up pitest in a Maven project.
+- Pitest (Mutation Testing for Java) can help improve the logical coverage of code through tests.
+  - Code coverage is also helpful. However, executing a line in a test does not necessarily mean that the content of the line is thoroughly tested.
+  - Example: For `if (a < 5)`, tests with `a=2` and `a=10` generate full branch coverage. Changes to the constant `5` in the condition or off-by-one errors (e.g., using `<=` instead of `<`) are not detected by these tests. Pitest can detect this type of gap in the tests.
+- Regarding pitest
+  - Even pitest does not find all test gaps:
+    - Example: The same test gap is not detected for `if (a < 5.0)` (double instead of int) with tests `a=2.0` and `a=10.0`. I assume this is because there are no clear predecessors/successors for 5.0 in this case.
+  - Pitest requires `junit-jupiter-engine` as a dependency; `mvn test` and the test run from IDEA work without it.
+  - The error messages in pitest are not particularly user-friendly.
+- About finding potential crashes through tests with "random" input:
+  - fully randomized tests, e.g., with `@ParameterizedTest` and `@MethodSource` (and potentially Datafaker) don't work too well here
+  - dedicated fuzz-testing libraries (e.g., Jazzer) are significantly better suited 
+- About Datafaker:
+  - it appears to be a good candidate for tests with realistic but random data in Java
+  - seems to be aimed at providing reality-like fake data for tests
+  - might help to prevent business logic problems stemming from overly specific test cases
+  - isn't well-suited for finding rare crash conditions 
+- Jqwik could be a good candidate for property-based testing in Java.
+  - It attempts, for example, to simplify a found test-breaking input to get as close as possible to a minimal reproducing sample.
+  - Test with slightly complicated div by zero cases were detected in reasonable time
+
+## working notes
 - totalToys == 0
 - age < 0
 - setup of pitest not straightforward

--- a/exercise/java/day11/log.md
+++ b/exercise/java/day11/log.md
@@ -17,4 +17,6 @@
     - are fuzzing libs better at detecting corner cases?  
 - review of pitest findings:
   - ! can alter doubles in ensureToyBalance without a test failing
-  - 
+- toying with jazzer
+  - found div by zero problems in several variations (+/- small constants, +/- other var) rather quickly
+    - to introduce div by zero, i changed `(double) toysCount / totalToys` to variations of `(double) (toysCount / totalToys)`

--- a/exercise/java/day11/pom.xml
+++ b/exercise/java/day11/pom.xml
@@ -54,6 +54,11 @@
             <artifactId>jazzer-junit</artifactId>
             <version>0.22.1</version>
         </dependency>
+        <dependency>
+            <groupId>net.jqwik</groupId>
+            <artifactId>jqwik</artifactId>
+            <version>1.9.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/exercise/java/day11/pom.xml
+++ b/exercise/java/day11/pom.xml
@@ -49,6 +49,11 @@
             <version>2.4.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.code-intelligence</groupId>
+            <artifactId>jazzer-junit</artifactId>
+            <version>0.22.1</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -78,6 +83,9 @@
                     <targetTests>
                         <param>christmas.*</param> <!-- Adjust according to your test packages -->
                     </targetTests>
+                    <mutators>
+                        <mutator>DEFAULT</mutator>
+                    </mutators>
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/exercise/java/day11/pom.xml
+++ b/exercise/java/day11/pom.xml
@@ -84,7 +84,7 @@
                         <param>christmas.*</param> <!-- Adjust according to your test packages -->
                     </targetTests>
                     <mutators>
-                        <mutator>DEFAULT</mutator>
+                        <mutator>STRONGER</mutator>
                     </mutators>
                 </configuration>
                 <dependencies>

--- a/exercise/java/day11/pom.xml
+++ b/exercise/java/day11/pom.xml
@@ -32,6 +32,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>${assertj.version}</version>
@@ -55,6 +61,27 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven.surefire.version}</version>
             </plugin>
+            <plugin>
+                <groupId>org.pitest</groupId>
+                <artifactId>pitest-maven</artifactId>
+                <version>1.17.1</version> <!-- Make sure to check for the latest version -->
+                <configuration>
+                    <targetClasses>
+                        <param>christmas.*</param> <!-- Adjust according to your packages -->
+                    </targetClasses>
+                    <targetTests>
+                        <param>christmas.*</param> <!-- Adjust according to your test packages -->
+                    </targetTests>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.pitest</groupId>
+                        <artifactId>pitest-junit5-plugin</artifactId>
+                        <version>1.2.1</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+
         </plugins>
     </build>
 </project>

--- a/exercise/java/day11/pom.xml
+++ b/exercise/java/day11/pom.xml
@@ -43,6 +43,12 @@
             <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.datafaker</groupId>
+            <artifactId>datafaker</artifactId>
+            <version>2.4.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/exercise/java/day11/src/test/java/christmas/PreparationTests.java
+++ b/exercise/java/day11/src/test/java/christmas/PreparationTests.java
@@ -3,12 +3,10 @@ package christmas;
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.code_intelligence.jazzer.junit.FuzzTest;
 import net.datafaker.Faker;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.MethodSource;
-
-import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -62,7 +60,7 @@ class PreparationTests {
     }
 
     // "Fuzz" tests using datafaker -> not that clever
-
+    /*
     @ParameterizedTest
     @MethodSource
     void prepareGiftsShouldNotCrashWithRandomInput(int numberOfGifts) {
@@ -96,6 +94,7 @@ class PreparationTests {
                         Arguments.of(faker.options().option(ToyType.class), faker.random().nextInt(), faker.random().nextInt()))
                 .limit(10000);
     }
+     */
 
     // hopefully better fuzz test using jazzer
     @FuzzTest
@@ -104,4 +103,21 @@ class PreparationTests {
         Preparation.categorizeGift(data.consumeInt());
         Preparation.ensureToyBalance(data.pickValue(ToyType.values()), data.consumeInt(), data.consumeInt());
     }
+
+    @Property
+    void prepareGiftsShouldNotCrashWithRandomInput(@ForAll int numberOfGifts) {
+        Preparation.prepareGifts(numberOfGifts);
+    }
+
+    @Property
+    void categorizeGiftShouldNotCrashWithRandomInput(@ForAll int age) {
+        Preparation.categorizeGift(age);
+    }
+
+    //detected div by zero in 100000 iterations on the following variant: double typePercentage = toysCount / (totalToys + (toysCount + 5) * 2 - 100);
+    @Property(tries = 100000)
+    void ensureToyBalanceShouldNotCrashWithRandomInput(@ForAll ToyType toyType, @ForAll int toysCount, @ForAll int totalToys) {
+        Preparation.ensureToyBalance(toyType, toysCount, totalToys);
+    }
+
 }

--- a/exercise/java/day11/src/test/java/christmas/PreparationTests.java
+++ b/exercise/java/day11/src/test/java/christmas/PreparationTests.java
@@ -1,11 +1,19 @@
 package christmas;
 
+import net.datafaker.Faker;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class PreparationTests {
+
+    private static final Faker faker = new Faker();
 
     @ParameterizedTest
     @CsvSource({
@@ -47,5 +55,41 @@ class PreparationTests {
     void ensureToyBalance(ToyType toyType, int toysCount, int totalToys, boolean expected) {
         boolean result = Preparation.ensureToyBalance(toyType, toysCount, totalToys);
         assertThat(result).isEqualTo(expected);
+    }
+
+    // "Fuzz" tests using datafaker -> not that clever
+
+    @ParameterizedTest
+    @MethodSource
+    void prepareGiftsShouldNotCrashWithRandomInput(int numberOfGifts) {
+        Preparation.prepareGifts(numberOfGifts);
+    }
+
+    static Stream<Arguments> prepareGiftsShouldNotCrashWithRandomInput() {
+        return Stream.generate(() -> Arguments.of(faker.random().nextInt()))
+                .limit(10000);
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void categorizeGiftShouldNotCrashWithRandomInput(int age) {
+        Preparation.categorizeGift(age);
+    }
+
+    static Stream<Arguments> categorizeGiftShouldNotCrashWithRandomInput() {
+        return Stream.generate(() -> Arguments.of(faker.random().nextInt()))
+                .limit(10000);
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void ensureToyBalanceShouldNotCrashWithRandomInput(ToyType toyType, int toysCount, int totalToys) {
+        Preparation.ensureToyBalance(toyType, toysCount, totalToys);
+    }
+
+    static Stream<Arguments> ensureToyBalanceShouldNotCrashWithRandomInput() {
+        return Stream.generate(() ->
+                        Arguments.of(faker.options().option(ToyType.class), faker.random().nextInt(), faker.random().nextInt()))
+                .limit(10000);
     }
 }

--- a/exercise/java/day11/src/test/java/christmas/PreparationTests.java
+++ b/exercise/java/day11/src/test/java/christmas/PreparationTests.java
@@ -3,7 +3,6 @@ package christmas;
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.code_intelligence.jazzer.junit.FuzzTest;
 import net.datafaker.Faker;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -50,8 +49,11 @@ class PreparationTests {
             "EDUCATIONAL, 25, 100, true",
             "FUN, 30, 100, true",
             "CREATIVE, 20, 100, true",
+            "EDUCATIONAL, 249, 1000, false",
             "EDUCATIONAL, 20, 100, false",
+            "FUN, 299, 1000, false",
             "FUN, 29, 100, false",
+            "CREATIVE, 199, 1000, false",
             "CREATIVE, 15, 100, false"
     })
     void ensureToyBalance(ToyType toyType, int toysCount, int totalToys, boolean expected) {

--- a/exercise/java/day11/src/test/java/christmas/PreparationTests.java
+++ b/exercise/java/day11/src/test/java/christmas/PreparationTests.java
@@ -1,5 +1,5 @@
-import christmas.Preparation;
-import christmas.ToyType;
+package christmas;
+
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -23,8 +23,11 @@ class PreparationTests {
     @ParameterizedTest
     @CsvSource({
             "1, Baby",
+            "2, Baby",
             "3, Toddler",
+            "5, Toddler",
             "6, Child",
+            "12, Child",
             "13, Teen"
     })
     void categorizeGift(int age, String expectedCategory) {

--- a/exercise/java/day11/src/test/java/christmas/PreparationTests.java
+++ b/exercise/java/day11/src/test/java/christmas/PreparationTests.java
@@ -1,5 +1,7 @@
 package christmas;
 
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.code_intelligence.jazzer.junit.FuzzTest;
 import net.datafaker.Faker;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -91,5 +93,13 @@ class PreparationTests {
         return Stream.generate(() ->
                         Arguments.of(faker.options().option(ToyType.class), faker.random().nextInt(), faker.random().nextInt()))
                 .limit(10000);
+    }
+
+    // hopefully better fuzz test using jazzer
+    @FuzzTest
+    void fuzzTest(FuzzedDataProvider data) {
+        Preparation.prepareGifts(data.consumeInt());
+        Preparation.categorizeGift(data.consumeInt());
+        Preparation.ensureToyBalance(data.pickValue(ToyType.values()), data.consumeInt(), data.consumeInt());
     }
 }


### PR DESCRIPTION
My highlights from day 11:

- Pitest (Mutation testing for java)
  - can help spot logical loopholes in tests
  - does not spot all logical  loopholes (i.e. "off by a little" in floating point numbers)
  - can be hard to set up
- about spotting edge cases that lead to bugs
  - tests with purely random generated data (or datafaker) have a very bad chance of catching those bugs  
  - dedicated fuzz testing (i.e. with jazzer) does way better in this regard, but is hard to set up
  - dedicated property based testing (jqwick) also works well and was a breeze to set up
- datafaker is nice for generating reality-like data nonetheless

See notes.md if you are interested in more details (not as detailed as in previous days).
See the commits logs if you want to retrace my steps while working on the exercise (not too detailed today).